### PR TITLE
Adding ETargetType enum for spells

### DIFF
--- a/Source/ProjectRogue/ProjectRogueCharacter.h
+++ b/Source/ProjectRogue/ProjectRogueCharacter.h
@@ -299,6 +299,7 @@ public:
 	int32 GetKeyboardSelectedAdventurer() const;
 
 private:
+	bool CastSpell(ASpell* Spell, UCharacterData* SpellTarget = nullptr);
 	void CreateAllItems();
 	void CreateAllSpells();
 

--- a/Source/ProjectRogue/Spell.cpp
+++ b/Source/ProjectRogue/Spell.cpp
@@ -14,9 +14,10 @@ ASpell::ASpell()
 }
 
 //TODO: can i use move operator here? very low priority
-void ASpell::Init(AProjectRogueCharacter* InPlayer, ESpellType InType, const int32 InLevel, const int32 InManaCost, const int32 InRange, const FString& InName, const FString& InDescription, const TFunction<bool(UCharacterData*)> InCallback)
+void ASpell::Init(AProjectRogueCharacter* InPlayer, ESpellType InSpellType, ETargetType InTargetType, const int32 InLevel, const int32 InManaCost, const int32 InRange, const FString& InName, const FString& InDescription, const TFunction<bool(UCharacterData*)> InCallback)
 {
-	Type = InType;
+	Type = InSpellType;
+	TargetType = InTargetType;
 	Player = InPlayer;
 	Level = InLevel;
 	ManaCost = InManaCost;
@@ -28,7 +29,8 @@ void ASpell::Init(AProjectRogueCharacter* InPlayer, ESpellType InType, const int
 
 bool ASpell::RunCallback(UCharacterData* Character)
 {
-	checkf(Character, TEXT("Cannot run spell callback: Character is nullptr"));
+	//area spells do not require a callback target, so this assert doesnt work
+	//checkf(Character, TEXT("Cannot run spell callback: Character is nullptr"));
 	return Callback(Character);
 }
 

--- a/Source/ProjectRogue/Spell.h
+++ b/Source/ProjectRogue/Spell.h
@@ -17,6 +17,13 @@ enum class ESpellType : uint8
 	Prayer,
 };
 
+UENUM()
+enum class ETargetType : uint8
+{
+	Single,
+	Area,
+};
+
 UCLASS()
 class PROJECTROGUE_API ASpell : public AActor
 {
@@ -25,6 +32,7 @@ class PROJECTROGUE_API ASpell : public AActor
 private:
 	AProjectRogueCharacter* Player;
 	ESpellType Type;
+	ETargetType TargetType;
 	int32 Level;
 	int32 ManaCost;
 	int32 Range;
@@ -36,10 +44,11 @@ public:
 	// Sets default values for this actor's properties
 	ASpell();
 
-	void Init(AProjectRogueCharacter* InPlayer, ESpellType InType, const int32 InLevel, const int32 InManaCost, const int32 InRange, const FString& InName, const FString& InDescription, const TFunction<bool(UCharacterData*)> InCallback);
-	bool RunCallback(UCharacterData* Character);
+	void Init(AProjectRogueCharacter* InPlayer, ESpellType InSpellType, ETargetType InTargetType, const int32 InLevel, const int32 InManaCost, const int32 InRange, const FString& InName, const FString& InDescription, const TFunction<bool(UCharacterData*)> InCallback);
+	bool RunCallback(UCharacterData* Character = nullptr);
 
 	ESpellType GetSpellType() const { return Type; }
+	ETargetType GetTargetType() const { return TargetType; }
 	const int32& GetLevel() const { return Level; }
 	const int32& GetManaCost() const { return ManaCost; }
 	const int32& GetRange() const { return Range; }


### PR DESCRIPTION
Adding an enum so that spells with no target can be cast without needing to use the same character selection menu as spells with a target